### PR TITLE
Fix darwin OSTYPE regardless of CPU arch.

### DIFF
--- a/zsh-direnv.plugin.zsh
+++ b/zsh-direnv.plugin.zsh
@@ -49,8 +49,6 @@ _zsh_direnv_download_install() {
         ;;
       arm64)
         machine=arm64
-        # if on Darwin, trim $OSTYPE to match the direnv release
-        [[ "$OSTYPE" == "darwin"* ]] && local OSTYPE=darwin
         ;;
       i686 | i386)
         machine=386
@@ -60,6 +58,8 @@ _zsh_direnv_download_install() {
         return 1
       ;;
     esac
+    # if on Darwin, trim $OSTYPE to match the direnv release
+    [[ "$OSTYPE" == "darwin"* ]] && local OSTYPE=darwin
     _zsh_direnv_log $NONE "blue" "  -> download and install direnv ${version}"
     curl -o "${DIRENV_HOME}/direnv" -fsSL https://github.com/direnv/direnv/releases/download/${version}/direnv.${OSTYPE%-*}-${machine}
     chmod +x "${DIRENV_HOME}/direnv"


### PR DESCRIPTION
Darwin as an OSTYPE is not only used on arm64, but also on amd64. This change
fixes the OSTYPE regardless for all CPU archs.

Tested on darwin21.0 (amd64) and linux-gnu (amd64).
