### PR TITLE
fix: Add alias for aarch64 machine type

### DIFF
--- a/zsh-direnv.plugin.zsh
+++ b/zsh-direnv.plugin.zsh
@@ -50,6 +50,9 @@ _zsh_direnv_download_install() {
       arm64)
         machine=arm64
         ;;
+      aarch64)
+        machine=arm64
+        ;;
       i686 | i386)
         machine=386
         ;;


### PR DESCRIPTION
[Technically](https://en.wikipedia.org/wiki/AArch64), the correct name for `arm64` is `aarch64`. 

On Raspbian, and IIRC any other Linux running on 64 bits arm CPU `uname -m` returns `aarch64`. However, on macOS on m1, I believe, it's `arm64`. They both refer to the same thing. Anyways, we have to "support" both names.

I've verified that `direnv.linux-arm64` release binary in `direnv` itself works as expected.